### PR TITLE
feat(flatpak): add gitbutler package and remove duplicate

### DIFF
--- a/nix/systems/x86_64-linux/nixos-pc/default.nix
+++ b/nix/systems/x86_64-linux/nixos-pc/default.nix
@@ -294,7 +294,10 @@
 
   services.flatpak = {
     enable = true;
-    packages = [ "com.surfshark.Surfshark" ];
+    packages = [
+      "com.surfshark.Surfshark"
+      "com.gitbutler.gitbutler"
+    ];
     update.auto = {
       enable = true;
       onCalendar = "weekly";
@@ -384,7 +387,6 @@
     unstable.github-copilot-cli
 
     custom.danbooru-rs
-    custom.gitbutler
     custom.shiru
   ];
 


### PR DESCRIPTION
Add "com.gitbutler.gitbutler" to the Flatpak packages list so the
gitbutler application is installed and managed via Flatpak.

Remove the redundant custom.gitbutler entry from the custom package
list to avoid duplication and potential conflicts between custom and
Flatpak-managed installations.

Keep auto-updates enabled weekly for Flatpak packages.